### PR TITLE
Simplify API for read access.

### DIFF
--- a/examples/example-02-sync-read/example-02-sync-read.cpp
+++ b/examples/example-02-sync-read/example-02-sync-read.cpp
@@ -57,8 +57,7 @@ int main(int argc, char **argv) try
   /* Read the current angle from all those servos
    * and print it to std::cout.
    */
-  std::map<Dynamixel::Id, uint32_t> position_map;
-  dynamixel_ctrl.syncRead(MX28_ControlTable_PresentPosition, id_vect, position_map);
+  std::map<Dynamixel::Id, uint32_t> const position_map = dynamixel_ctrl.syncRead<uint32_t>(MX28_ControlTable_PresentPosition, id_vect);
 
   for (auto [id, position_raw] : position_map)
   {

--- a/examples/example-04-read/example-04-read.cpp
+++ b/examples/example-04-read/example-04-read.cpp
@@ -61,8 +61,7 @@ int main(int argc, char **argv) try
 
   for (auto id: id_vect)
   {
-    uint8_t firmware_version = 0;
-    dynamixel_ctrl.read(MX28_ControlTable_Firmware_Version, id, firmware_version);
+    uint8_t const firmware_version = dynamixel_ctrl.read<uint8_t>(MX28_ControlTable_Firmware_Version, id);
 
     std::cout << "Servo #" << static_cast<int>(id)
               << " firmware version rev. " << static_cast<int>(firmware_version) << std::endl;

--- a/examples/example-xx-minimal/example-xx-minimal.cpp
+++ b/examples/example-xx-minimal/example-xx-minimal.cpp
@@ -27,8 +27,7 @@ int main(int argc, char **argv) try
   dynamixel_ctrl.syncWrite(MX28_ControlTable_Torque_Enable, goal_position_data_map);
 
   /* Read current position. */
-  std::map<Dynamixel::Id, uint32_t> position_map;
-  dynamixel_ctrl.syncRead(MX28_ControlTable_PresentPosition, id_vect, position_map);
+  std::map<Dynamixel::Id, uint32_t> const position_map = dynamixel_ctrl.syncRead<uint32_t>(MX28_ControlTable_PresentPosition, id_vect);
 
   for (auto [id, position_raw] : position_map)
     std::cout << "Dynamixel MX28 servo #" << static_cast<int>(id) << ": " << position_raw << std::endl;

--- a/include/dynamixel++/Dynamixel++.h
+++ b/include/dynamixel++/Dynamixel++.h
@@ -36,8 +36,8 @@
 
 #define _107_LIBDYNAMIXELPLUSPLUS_BASE_VERSION \
         _107_LIBDYNAMIXELPLUSPLUS_BASE_CONCAT_VERSION(_107_LIBDYNAMIXELPLUSPLUS_BASE_MAJOR, \
-                                                _107_LIBDYNAMIXELPLUSPLUS_BASE_MINOR, \
-                                                _107_LIBDYNAMIXELPLUSPLUS_BASE_PATCH)
+                                                      _107_LIBDYNAMIXELPLUSPLUS_BASE_MINOR, \
+                                                      _107_LIBDYNAMIXELPLUSPLUS_BASE_PATCH)
 
 /**************************************************************************************
  * NAMESPACE
@@ -78,8 +78,8 @@ public:
 
   void reboot(Id const id);
 
-  template<typename T> void read    (uint16_t const start_address, Id const id, T & val);
-  template<typename T> void syncRead(uint16_t const start_address, IdVect const & id_vect, std::map<Id, T> & val_map);
+  template<typename T> T               read    (uint16_t const start_address, Id const id);
+  template<typename T> std::map<Id, T> syncRead(uint16_t const start_address, IdVect const & id_vect);
 
   template<typename T> void write    (uint16_t const start_address, Id const id, T const val);
   template<typename T> void syncWrite(uint16_t const start_address, std::map<Id, T> const & val_map);


### PR DESCRIPTION
This has been made possible by freeing the return value from transporting an error code.